### PR TITLE
nsfw channel requirement

### DIFF
--- a/commands/imagine.js
+++ b/commands/imagine.js
@@ -22,7 +22,14 @@ module.exports = {
                         }
 
                         const imageURLs = response.join('\n')
+                        
+                                if (interaction.channel.nsfw === true) {
+                        
                         interaction.editReply(`**${prompt}**\n${imageURLs}`)
+                                
+                               }else {            
+                           interaction.editReply({content: 'Must be a Age Restricted channel to function', ephemeral: true });
+                       } 
 
                 })
 


### PR DESCRIPTION
Since the model does output nsfw images when requested, It's safe to add Age-Restricted channels only requirement.